### PR TITLE
Get Save Image Working

### DIFF
--- a/src/main/java/com/antew/redditinpictures/library/Constants.java
+++ b/src/main/java/com/antew/redditinpictures/library/Constants.java
@@ -121,7 +121,6 @@ public class Constants {
 
     public static class Broadcast {
         private static final String BROADCAST_PREFIX             = PACKAGE_PREFIX + ".broadcast.";
-        public static final  String BROADCAST_DOWNLOAD_IMAGE     = BROADCAST_PREFIX + "download-image";
         public static final  String BROADCAST_ABOUT_SUBREDDIT    = BROADCAST_PREFIX + "about-subreddit";
         public static final  String BROADCAST_HTTP_FINISHED      = BROADCAST_PREFIX + "http-finished";
         public static final  String BROADCAST_LOGIN_COMPLETE     = BROADCAST_PREFIX + "login-complete";

--- a/src/main/java/com/antew/redditinpictures/library/ui/ImageDetailActivity.java
+++ b/src/main/java/com/antew/redditinpictures/library/ui/ImageDetailActivity.java
@@ -41,6 +41,7 @@ import com.antew.redditinpictures.library.model.reddit.RedditUrl;
 import com.antew.redditinpictures.library.preferences.SharedPreferencesHelper;
 import com.antew.redditinpictures.library.service.RedditService;
 import com.antew.redditinpictures.library.util.BundleUtil;
+import com.antew.redditinpictures.library.util.ImageUtil;
 import com.antew.redditinpictures.library.util.Ln;
 import com.antew.redditinpictures.library.util.PostUtil;
 import com.antew.redditinpictures.library.util.StringUtil;
@@ -49,6 +50,7 @@ import com.antew.redditinpictures.library.util.SubredditUtil;
 import com.antew.redditinpictures.pro.R;
 import com.google.analytics.tracking.android.EasyTracker;
 import com.google.analytics.tracking.android.MapBuilder;
+import com.squareup.picasso.Picasso;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -251,11 +253,8 @@ public class ImageDetailActivity extends ImageViewerActivity implements LoaderMa
 
     @Override
     public void onFinishSaveImageDialog(String filename) {
-        PostData p = getAdapter().getPost(mPager.getCurrentItem());
-        Intent intent = new Intent(Constants.Broadcast.BROADCAST_DOWNLOAD_IMAGE);
-        intent.putExtra(Constants.Extra.EXTRA_PERMALINK, p.getPermalink());
-        intent.putExtra(Constants.Extra.EXTRA_FILENAME, filename);
-        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+        PostData postData = getAdapter().getPost(mPager.getCurrentItem());
+        ImageUtil.downloadImage(this, postData.getUrl(), filename);
     }
 
     public boolean isRequestInProgress() {

--- a/src/main/java/com/antew/redditinpictures/library/ui/ImgurAlbumActivity.java
+++ b/src/main/java/com/antew/redditinpictures/library/ui/ImgurAlbumActivity.java
@@ -9,6 +9,7 @@ import com.antew.redditinpictures.library.Constants;
 import com.antew.redditinpictures.library.adapter.ImgurAlbumPagerAdapter;
 import com.antew.redditinpictures.library.imgur.ImgurAlbumApi.Album;
 import com.antew.redditinpictures.library.imgur.ImgurImageApi.ImgurImage;
+import com.antew.redditinpictures.library.util.ImageUtil;
 import com.antew.redditinpictures.library.util.StringUtil;
 import com.antew.redditinpictures.pro.R;
 import java.util.List;
@@ -92,11 +93,8 @@ public class ImgurAlbumActivity extends ImageViewerActivity {
 
     @Override
     public void onFinishSaveImageDialog(String filename) {
-        ImgurImage p = getAdapter().getImage(mPager.getCurrentItem());
-        Intent intent = new Intent(Constants.Broadcast.BROADCAST_DOWNLOAD_IMAGE);
-        intent.putExtra(Constants.Extra.EXTRA_IMAGE_HASH, p.getImage().getHash());
-        intent.putExtra(Constants.Extra.EXTRA_FILENAME, filename);
-        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+        ImgurImage image = getAdapter().getImage(mPager.getCurrentItem());
+        ImageUtil.downloadImage(this, image.getLinks().getOriginal(), filename);
     }
 
     private ImgurAlbumPagerAdapter getAdapter() {


### PR DESCRIPTION
Images are now able to be saved when in an Album view or viewing a single image. They are saved to the public Pictures directory as provided by the device.

Images are now correctly saved from both viewing a single image and when in an Album activity. But, when viewing a single image that is an album (so the cover is being displayed by the ImageDetailFragment) the image is not currently able to be saved.

I took a look at what we would have to do and it looks like it would require a bit of refactoring to get this working well and it would also require (potentially) some additional network calls if we lost the data from the cache. We'll need to evaluate this more before we start adding that functionality.
